### PR TITLE
Update script and readme for OBS 31+

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,21 @@ These settings are also exposed in the script properties, visible in OBS Studio'
 
 ## Languages other than english
 If you use OBS in another language, this script will not work properly. To fix this change the following properties:
-- (Preview) window
-- Windowed Projector
-- Fullscreen Projector
+- Preview
+- Program
+- Projector
 
-From the How to Use instructions, check the title for the projected window. The part inside the parenthesis should go to the "(Preview) window" (including the parenthesis), the rest of the title should either to "Windowed/Fullscreen Projector" 
+From the How to Use instructions, check the title for the projected window. The part before the hyphen (-) should go in the "Projector" field. 
+The part after the hyphen will go into either the "Preview" or "Program" field, depending on if you're projecting the preview window (available in both studio and non-studio) or live window (only available in studio mode).
+In English, for example, the projector window titles would look like this:
+    * Projector - Preview
+    * Projector - Program
 
 ### Spanish
 In spanish you can set the values as follows:
-- (Preview) window: (Previsualización)
-- Windowed Projector: Proyector con ventana
-- Fullscreen Projector: Proyector de pantalla completa
+- Preview: Vista Previa
+- Program: Programa
+- Projector: Proyector
 
 # Known Issues
 - Script settings windows does not update when hotkeys are used.
@@ -43,6 +47,13 @@ In spanish you can set the values as follows:
 - Whiteboard source starts minimized sometimes.
   * Some users have reported that newly added whiteboard sources show up minimized. Setting its size to 'Fit to Screen' seems to resolve this.
 
+- Whiteboard source does not work after reloading script.
+  * Existing sources may need to be toggled off/on to get them to respect the new settings. Alternatively, restarting OBS or switching scenes should also fix the issue.
+  
+- Whiteboard source appears in red text in the list of sources.
+  * This appears to be a limitation of OBS, unfortunately. The sources are checked at startup only, and the whiteboard sources aren't activated at that time, so they permanently appear red, even when functioning correctly.
+  * See https://obsproject.com/forum/threads/lua-script-plugin-type-obs_source_type_input-shown-in-red-on-obs-32.191001/#post-693786 for a short discussion on this.
+  
 
 # Authors
 **mwelsh** *([TILT forums](http://tiltforums.com/u/mwelsh))*  *([github](https://github.com/Herschel/obs-whiteboard))*  

--- a/whiteboard.lua
+++ b/whiteboard.lua
@@ -1,6 +1,6 @@
 -- OBS Whiteboard Script
 -- Authors: Mike Welsh (mwelsh@gmail.com), Tari
--- v1.3
+-- v1.4
 
 
 obs             = obslua
@@ -14,10 +14,9 @@ toggle_size     = false
 eraser          = false
 scene_name      = nil
 setting_update  = false
-preview_name = "(Preview)"
-program_name = "(Program)"
-window_projector_name = "Windowed Projector"
-fullscreen_projector_name = "Fullscreen Projector"
+preview_name = "Preview"
+program_name = "Program"
+projector_name = "Projector"
 
 eraser_v4     = obs.vec4()
 color_count   = 6  -- The color at index color_count is reserved for user-defined custom colors.
@@ -124,8 +123,7 @@ function script_update(settings)
     size = size_value
     preview_name = preview_value
     program_name = program_value
-    window_projector_name = windowed_value
-    fullscreen_projector_name = fullscreen_value
+    projector_name = windowed_value
     
     -- Set custom color in the color array (always last element).
     color_array[color_count] = obs.obs_data_get_int(settings, "custom_color")
@@ -248,9 +246,7 @@ source_def.video_tick = function(data, dt)
         
         local window = winapi.GetForegroundWindow()
         window_name = winapi.InternalGetWindowText(window, nil)
-        if window_match(window_name) and 
-        (string.find(window_name, window_projector_name, 1, true) or
-        string.find(window_name, fullscreen_projector_name, 1, true)) then
+        if window_match(window_name) and string.find(window_name, projector_name, 1, true) then
             winapi.ScreenToClient(window, mouse_pos)
             local window_rect = winapi.GetClientRect(window)
             
@@ -371,12 +367,12 @@ end
 
 -- Check whether current foreground window is relevant to us.
 function window_match(window_name)
-    
+
     local valid_names = {}
     
     -- If studio mode is enabled, only allow drawing on main
-    -- window (Program). If non-studio mode, allow drawing on
-    -- the (Preview) window, instead.
+    -- window "Program". If non-studio mode, allow drawing on
+    -- the "Preview" window, instead.
     if obs.obs_frontend_preview_program_mode_active() then
         table.insert(valid_names, program_name)
     else
@@ -591,13 +587,11 @@ function script_properties()
     
     local eraser_toggle = obs.obs_properties_add_bool(properties, "eraser", "Eraser")
     
-    local preview_value = obs.obs_properties_add_text(properties, "preview_value", "(Preview) window",  obs.OBS_TEXT_DEFAULT)
+    local preview_value = obs.obs_properties_add_text(properties, "preview_value", "Preview",  obs.OBS_TEXT_DEFAULT)
     
-    local program_value = obs.obs_properties_add_text(properties, "program_value", "(Program) window",  obs.OBS_TEXT_DEFAULT)
+    local program_value = obs.obs_properties_add_text(properties, "program_value", "Program",  obs.OBS_TEXT_DEFAULT)
     
-    local windowed_value = obs.obs_properties_add_text(properties, "windowed_value", "Windowed Projector", obs.OBS_TEXT_DEFAULT)
-    
-    local fullscreen_value = obs.obs_properties_add_text(properties, "fullscreen_value", "Fullscreen Projector", obs.OBS_TEXT_DEFAULT)
+    local windowed_value = obs.obs_properties_add_text(properties, "windowed_value", "Projector", obs.OBS_TEXT_DEFAULT)
     
     obs.obs_properties_add_button(properties, "clear", "Clear Whiteboard", clear_button)
     
@@ -614,18 +608,16 @@ function script_defaults(settings)
     obs.obs_data_set_default_int(settings, "size", 2)
     obs.obs_data_set_default_bool(settings, "eraser", false)
     obs.obs_data_set_default_int(settings, "custom_color", 0xFF000000)
-    obs.obs_data_set_default_string(settings, "preview_value", "(Preview)")
-    obs.obs_data_set_default_string(settings, "program_value", "(Program)")
-    obs.obs_data_set_default_string(settings, "windowed_value", "Windowed Projector")
-    obs.obs_data_set_default_string(settings, "fullscreen_value", "Fullscreen Projector")
+    obs.obs_data_set_default_string(settings, "preview_value", "Preview")
+    obs.obs_data_set_default_string(settings, "program_value", "Program")
+    obs.obs_data_set_default_string(settings, "windowed_value", "Projector")
     
     color_index = 5
     size = 2
     eraser = false
-    preview_name = "(Preview)"
-    program_name = "(Program)"
-    window_projector_name = "Windowed Projector"
-    fullscreen_projector_name = "Fullscreen Projector"
+    preview_name = "Preview"
+    program_name = "Program"
+    projector_name = "Projector"
 end
 
 function script_description()
@@ -638,7 +630,7 @@ Hotkeys can be set to toggle color, size, and eraser. An additional hotkey can b
     
 The settings on this page will unfortunately not update in real-time when using hotkeys, due to limitations with OBS's script properties.]
 
-If using a language other than english: (Preview) window, (Program) window, Windowed Projector and Fullscreen Projector must be updated with the corresponding language names (Check README.md file). ]==]
+If using a language other than english: "Preview", "Program", and "Projector" must be updated with the corresponding language names (Check README.md file). ]==]
 end
 
 


### PR DESCRIPTION
- Remove differentiation between "Windowed Projector" and "Fullscreen Projector" as they've been consolidated into the same window title ("Projector"). 
- Update defaults and README.
- Add explanation for why the script appears red in the source list.

https://github.com/katarai/obs-whiteboard-lua/issues/8 noted this issue earlier. :)